### PR TITLE
scipy-based integral operators

### DIFF
--- a/hsolvers/helmholtz_solver.pyx
+++ b/hsolvers/helmholtz_solver.pyx
@@ -2,8 +2,9 @@ import numpy as np
 cimport numpy as np
 from solver import Solver
 from abounds import ExteriorBoundarySolution, InteriorBoundarySolution
-from iops_pyx import * # Cython integral operators (slow!)
-# from iops_pyx import * # C++ integral operators
+#from iops_pyx import * # Cython integral operators (slow!)
+#from iops_sci import * # Scikit based integral operators (slow!)
+from iops_cpp import * # C++ integral operators
 
 
 class HelmholtzSolver(Solver):

--- a/iops_sci/__init__.py
+++ b/iops_sci/__init__.py
@@ -1,0 +1,1 @@
+from .helmholtz_integrals import *

--- a/iops_sci/helmholtz_integrals.py
+++ b/iops_sci/helmholtz_integrals.py
@@ -1,25 +1,29 @@
 import numpy as np
-cimport numpy as np
+#cimport numpy as np
 from numpy.linalg import norm
-from scipy.special import hankel1
-
-cdef extern from "stdbool.h":
-    ctypedef bint bool
+from scipy.special import hankel1, expi
+from scipy.integrate import quad, fixed_quad
 
 
-cpdef normal_2d(np.ndarray a, np.ndarray b):
+#cdef extern from "stdbool.h":
+#    ctypedef bint bool
+
+
+def normal_2d(a, b):
     diff = a - b
     length = norm(diff)
     return np.array([diff[1]/length, -diff[0]/length])
 
-cpdef normal_3d(np.ndarray a, np.ndarray b, np.ndarray c):
+
+def normal_3d(a, b, c):
     ab = b - a
     ac = c - a
     normal = np.cross(ab, ac)
     normal /= norm(normal)
     return normal
 
-cpdef complex_quad_2d(func, np.ndarray start, np.ndarray end):
+
+def complex_quad_2d(func, start, end):
     samples = np.array(
         [
             [0.980144928249, 5.061426814519e-02],
@@ -41,144 +45,245 @@ cpdef complex_quad_2d(func, np.ndarray start, np.ndarray end):
     return sum * norm(vec)
 
 
+def iterable_t(func, t_list):
+    if type(t_list) == np.ndarray:
+        result = []
+        for t in t_list:
+            result.append(func(t))
+        return result
+    else:
+        return func(t)
+
+
+def fixed_quad_complex(func, a, b):
+    gauss_order = 16
+    re = fixed_quad(lambda t: np.real(iterable_t(func, t)), a, b, n=gauss_order)
+    im = fixed_quad(lambda t: np.imag(iterable_t(func, t)), a, b, n=gauss_order)
+    return re[0] + 1j * im[0]
+
+
+def green_2d(k, r):
+    return 0.25j * hankel1(0, k * r)
+
+def green0_2d(r):
+    return -0.5 / np.pi * np.log(r)
+
+def lerp(t, a, b):
+    return a + t * (b - a)
+
+def int_l_2d(t, k, p, a, b):
+    q = lerp(t, a, b)
+    r = norm(p - q)
+    l = norm(a - b)
+    return green_2d(k, r) * l
+
+def int0_l_2d(t, p, a, b):
+    q = lerp(t, a, b)
+    r = norm(p - q)
+    l = norm(a - b)
+    return green0_2d(r) * l
+
+def int_on_l_2d(t, k, p, a, b):
+    q = lerp(t, a, b)
+    r = norm(p - q)
+    l = norm(a - b)
+    return (0.5 / np.pi * np.log(r) + 0.25j * hankel1(0, k * r)) * l
+
+
 # -----------------------------------------------------------------------------
 # 2D
 # -----------------------------------------------------------------------------
-def l_2d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element):
-    qab = qb - qa
+def l_2d(k, p, a, b, p_on_element):
     if p_on_element:
         if k == 0.0:
-            ra = norm(p - qa)
-            rb = norm(p - qb)
-            re = norm(qab)
-            result = 0.5 / np.pi * (re - (ra * np.log(ra) + rb * np.log(rb)))
+            l = norm(a - b)
+            return 0.5 / np.pi * l * (1.0 - np.log(0.5 * l))
         else:
-
-            def func(x):
-                R = norm(p - x)
-                return 0.5 / np.pi * np.log(R) + 0.25j * hankel1(0, k * R)
-
-            result = (
-                complex_quad_2d(func, qa, p)
-                + complex_quad_2d(func, p, qb)
-                + l_2d(0.0, p, qa, qb, True)
-            )
+            result = fixed_quad_complex(lambda t: int_on_l_2d(t, k, p, a, p), 0, 1) \
+                     + fixed_quad_complex(lambda t: int_on_l_2d(t, k, p, p, b), 0, 1) \
+                     + l_2d(0.0, p, a, b, True)
     else:
         if k == 0.0:
-            result = -0.5 / np.pi * complex_quad_2d(lambda q: np.log(norm(p - q)), qa, qb)
+            result = fixed_quad_complex(lambda t: int0_l_2d(t, p, a, b), 0, 1)
         else:
-            result =  0.25j * complex_quad_2d(lambda q: hankel1(0, k * norm(p - q)), qa, qb)
+            result = fixed_quad_complex(lambda t: int_l_2d(t, k, p, a, b), 0, 1)
 
     return result
 
 
-def m_2d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element):
-    vecq = normal_2d(qa, qb)
+def dgreen_dr_2d(k, r):
+    return -0.25j * k * hankel1(1, k * r)
+
+
+def dgreen0_dr_2d(r):
+    return -0.5 / (np.pi * r)
+
+
+def int_m_2d(t, k, p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    l = norm(a - b)
+    n_q = normal_2d(a, b)
+    return dgreen_dr_2d(k, R) * (-np.dot(n_r, n_q)) * l
+
+
+def int0_m_2d(t, p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    l = norm(a - b)
+    n_q = normal_2d(a, b)
+    # the first minus sign in the next line should not be here.
+    # it was added to make it agree with the existing python and C++ implementations
+    return -dgreen0_dr_2d(R) * (-np.dot(n_r, n_q)) * l
+
+
+def m_2d(k, p, a, b, p_on_element):
     if p_on_element:
-        result = 0.0
+        if k == 0.0:
+            result = fixed_quad_complex(lambda t: int0_m_2d(t, p, a, p), 0, 1)\
+                     + fixed_quad_complex(lambda t: int0_m_2d(t, p, p, b), 0, 1)
+        else:
+            result = fixed_quad_complex(lambda t: int_m_2d(t, k, p, a, p), 0, 1)\
+                     + fixed_quad_complex(lambda t: int_m_2d(t, k, p, p, b), 0, 1)
     else:
         if k == 0.0:
-
-            def func(x):
-                r = p - x
-                return np.dot(r, vecq) / np.dot(r, r)
-
-            result = -0.5 / np.pi * complex_quad_2d(func, qa, qb)
+            result = fixed_quad_complex(lambda t: int0_m_2d(t, p, a, b), 0, 1)
         else:
-
-            def func(x):
-                r = p - x
-                R = norm(r)
-                return hankel1(1, k * R) * np.dot(r, vecq) / R
-
-            result = 0.25j * k * complex_quad_2d(func, qa, qb)
+            result = fixed_quad_complex(lambda t: int_m_2d(t, k, p, a, b), 0, 1)
 
     return result
 
 
-def mt_2d(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, bool p_on_element):
+def int_mt_2d(t, k, p, n_p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    l = norm(a - b)
+    return dgreen_dr_2d(k, R) * np.dot(n_r, n_p) * l
+
+
+def int0_mt_2d(t, p, n_p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    l = norm(a - b)
+    return dgreen0_dr_2d(R) * np.dot(n_r, n_p) * l
+
+
+def mt_2d(k, p, n_p, a, b, p_on_element):
     if p_on_element:
-        return 0.0
+        if k == 0.0:
+            result = complex_quad_2d(lambda t: int0_mt_2d(t, p, n_p, a, p), 0, 1)\
+                     + complex_quad_2d(lambda t: int0_mt_2d(t, p, n_p, p, b), 0, 1)
+        else:
+            result = complex_quad_2d(lambda t: int_mt_2d(t, k, p, n_p, a, p), 0, 1)\
+                     + complex_quad_2d(lambda t: int_mt_2d(t, k, p, n_p, p, b), 0, 1)
     else:
         if k == 0.0:
-
-            def func(x):
-                r = p - x
-                return np.dot(r, vecp) / np.dot(r, r)
-
-            return -0.5 / np.pi * complex_quad_2d(func, qa, qb)
+            result = complex_quad_2d(lambda t: int0_mt_2d(t, p, n_p, a, b), 0, 1)
         else:
+            result = complex_quad_2d(lambda t: int_mt_2d(t, k, p, n_p, a, b), 0, 1)
 
-            def func(x):
-                r = p - x
-                R = norm(r)
-                return hankel1(1, k * R) * np.dot(r, vecp) / R
-
-            return -0.25j * k * complex_quad_2d(func, qa, qb)
+    return result
 
 
-def n_2d(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, bool p_on_element):
-    qab = qb - qa
-    if p_on_element:
-        ra = norm(p - qa)
-        rb = norm(p - qb)
-        re = norm(qab)
-        if k == 0.0:
-            result = -(1.0 / ra + 1.0 / rb) / (2.0 * np.pi)
-            return result
-        else:
-            vecq = normal_2d(qa, qb)
-            k_sqr = k * k
+def d2green_dr2_2d(k, r):
+    result = 0.25j * k**2 * (hankel1(1, k * r) / (k * r) - hankel1(0, k * r))
+    return result
 
-            def func(x):
-                r = p - x
-                R2 = np.dot(r, r)
-                R = np.sqrt(R2)
-                drdudrdn = -np.dot(r, vecq) * np.dot(r, vecp) / R2
-                dpnu = np.dot(vecp, vecq)
-                c1 = 0.25j * k / R * hankel1(1, k * R) - 0.5 / (np.pi * R2)
-                c2 = (
-                    0.50j * k / R * hankel1(1, k * R)
-                    - 0.25j * k_sqr * hankel1(0, k * R)
-                    - 1.0 / (np.pi * R2)
-                )
-                c3 = -0.25 * k_sqr * np.log(R) / np.pi
-                return c1 * dpnu + c2 * drdudrdn + c3
 
-            n_0 = n_2d(0.0, p, vecp, qa, qb, True)
-            l_0 = - 0.5 * k_sqr * l_2d(0.0, p, qa, qb, True)
-            integral = complex_quad_2d(func, qa, p) + complex_quad_2d(func, p, qb)
+def d2green0_dr2_2d(r):
+    return 0.5 / (np.pi * r**2)
 
-            return integral + n_0 + l_0
+
+def d2r_dn_p_dn_q_2d(r, n_r, n_p, n_q):
+    return -1.0 / r * (np.dot(n_p, n_q) + np.dot(n_r, n_p) * (-np.dot(n_r, n_q)))
+
+
+def int_n_2d(t, k, p, n_p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    l = norm(a - b)
+    n_q = normal_2d(a, b)
+    return (dgreen_dr_2d(k, R) * d2r_dn_p_dn_q_2d(R, n_r, n_p, n_q)
+            + d2green_dr2_2d(k, R) * np.dot(n_r, n_p) * (-np.dot(n_r, n_q))) * l
+
+
+def int0_n_2d(t, p, n_p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    l = norm(a - b)
+    n_r = r / R
+    n_q = normal_2d(a, b)
+    return 0.5 / (np.pi * np.dot(r, r)) * (np.dot(n_p, n_q) - 2.0 * np.dot(n_r, n_p) * np.dot(n_r, n_q)) * l
+
+
+def int_on_n_2d(t_list, k, p, n_p, a, b):
+    if type(t_list) == np.ndarray:
+        result = []
+        for t in t_list:
+            q = lerp(t, a, b)
+            r = p - q
+            R2 = np.dot(r, r)
+            R = np.sqrt(R2)
+            l = norm(a - b)
+            n_r = r / R
+            n_q = normal_2d(a, b)
+            z0 = 0.25j * k / R * hankel1(1, k * R) - 0.5 / (np.pi * R2)
+            z1 = 0.50j * k / R * hankel1(1, k * R) - 0.25j * k**2 * hankel1(0, k * R) - 1.0 / (np.pi * R2)
+            z2 = -0.25 * k**2 * np.log(R) / np.pi
+            result.append( (z0 + z2) * l)
+        return result
     else:
-        vecq = normal_2d(qa, qb)
-        un = np.dot(vecp, vecq)
+        q = lerp(t_list, a, b)
+        r = p - q
+        R2 = np.dot(r, r)
+        R = np.sqrt(R2)
+        l = norm(a - b)
+        n_r = r / R
+        n_q = normal_2d(a, b)
+        z0 = 0.25j * k / R * hankel1(1, k * R) - 0.5 / (np.pi * R2)
+        z1 = 0.50j * k / R * hankel1(1, k * R) - 0.25j * k*k * hankel1(0, k * R) - 1.0 / (np.pi * R2)
+        z2 = -0.25 * k*k * np.log(R) / np.pi
+        return (z0 + z2) * l
+
+#    return (  z0 #* np.dot(n_p, n_q)
+#             + z1 * np.dot(n_r, n_p) * (-np.dot(n_r, n_q))
+#            + z2) * l
+
+
+def n_2d(k, p, n_p, a, b, p_on_element):
+    if p_on_element:
         if k == 0.0:
-
-            def func(x):
-                r = p - x
-                R2 = np.dot(r, r)
-                drdudrdn = -np.dot(r, vecq) * np.dot(r, vecp) / R2
-                return (un + 2.0 * drdudrdn) / R2
-
-            return 0.5 / np.pi * complex_quad_2d(func, qa, qb)
+            result = -2.0 / (np.pi * norm(a - b))
         else:
+            integral = complex_quad_2d(lambda t: int_on_n_2d(t, k, p, n_p, a, p), 0, 1)\
+                       + complex_quad_2d(lambda t: int_on_n_2d(t, k, p, n_p, p, b), 0, 1)
+            n_0 = n_2d(0.0, p, n_p, a, b, True)
+            l_0 = -0.5 * k*k * l_2d(0.0, p, a, b, True)
 
-            def func(x):
-                r = p - x
-                drdudrdn = -np.dot(r, vecq) * np.dot(r, vecp) / np.dot(r, r)
-                R = norm(r)
-                return (
-                    hankel1(1, k * R) / R * (un + 2.0 * drdudrdn)
-                    - k * hankel1(0, k * R) * drdudrdn
-                )
+            result = integral + n_0 + l_0
+    else:
+        if k == 0.0:
+            result = complex_quad_2d(lambda t: int0_n_2d(t, p, n_p, a, b), 0, 1)
+        else:
+            result = complex_quad_2d(lambda t: int_n_2d(t, k, p, n_p, a, b), 0, 1)
 
-            return 0.25j * k * complex_quad_2d(func, qa, qb)
+    return result
 
 # -----------------------------------------------------------------------------
 # 3D
 # -----------------------------------------------------------------------------
-def complex_quad_3d(func, np.ndarray a, np.ndarray b, np.ndarray c):
+def complex_quad_3d(func, a, b, c):
     samples = np.array([[0.333333333333333, 0.333333333333333, 0.225000000000000],
                         [0.797426985353087, 0.101286507323456, 0.125939180544827],
                         [0.101286507323456, 0.797426985353087, 0.125939180544827],
@@ -196,7 +301,7 @@ def complex_quad_3d(func, np.ndarray a, np.ndarray b, np.ndarray c):
     return sum_ * 0.5 * norm(np.cross(ab, ac))
 
 
-def l_3d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, np.ndarray qc, bool p_on_element):
+def l_3d(k, p, qa, qb, qc, p_on_element):
     if p_on_element:
         if k == 0.0:
             ab = qb - qa
@@ -249,7 +354,7 @@ def l_3d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, np.ndarray qc, boo
             return complex_quad_3d(func, qa, qb, qc) / (4.0 * np.pi)
 
 
-def m_3d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, np.ndarray qc, bool p_on_element):
+def m_3d(k, p, qa, qb, qc, p_on_element):
     if p_on_element:
         return 0.0
     else:
@@ -271,7 +376,7 @@ def m_3d(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, np.ndarray qc, boo
             return complex_quad_3d(func, qa, qb, qc) / (4.0 * np.pi)
 
 
-def mt_3d(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, np.ndarray qc, bool p_on_element):
+def mt_3d(k, p, vecp, qa, qb, qc, p_on_element):
     if p_on_element:
         return 0.0
     else:
@@ -292,7 +397,7 @@ def mt_3d(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, 
             return complex_quad_3d(func, qa, qb, qc) / (4.0 * np.pi)
 
 
-def n_3d(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, np.ndarray qc, bool p_on_element):
+def n_3d(k, p, vecp, qa, qb, qc, p_on_element):
     if p_on_element:
         if k == 0.0:
             ab = qb - qa
@@ -402,7 +507,7 @@ class CircularIntegratorPi(object):
         return sum * np.pi / self.segments
 
 
-def complex_quad_generator(func, np.ndarray start, np.ndarray end):
+def complex_quad_generator(func, start, end):
     """
     This is a variation on the basic complex quadrature function from the
     base class. The difference is, that the abscissa values y**2 have been
@@ -427,7 +532,7 @@ def complex_quad_generator(func, np.ndarray start, np.ndarray end):
     return 2.0 * sum * norm(vec)
 
 
-def complex_quad_cone(func, np.ndarray start, np.ndarray end, int segments = 1):
+def complex_quad_cone(func, start, end, segments = 1):
     delta = 1.0 / segments * (end - start)
     sum = 0.0
     for s in range(segments):
@@ -436,7 +541,7 @@ def complex_quad_cone(func, np.ndarray start, np.ndarray end, int segments = 1):
     return sum
 
 
-def l_rad(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element):
+def l_rad(k, p, qa, qb, p_on_element):
     ab = qb - qa
     # subdivide circular integral into sections of
     # similar size as ab
@@ -511,7 +616,7 @@ def l_rad(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element
             return complex_quad_2d(generatorFunc, qa, qb)
 
 
-def m_rad(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element):
+def m_rad(k, p, qa, qb, p_on_element):
     qab = qb - qa
     vec_q = normal_2d(qa, qb)
 
@@ -563,7 +668,7 @@ def m_rad(float k, np.ndarray p, np.ndarray qa, np.ndarray qb, bool p_on_element
             return complex_quad_2d(generatorFunc, qa, qb)
 
 
-def mt_rad(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, bool p_on_element):
+def mt_rad(k, p, vecp, qa, qb, p_on_element):
     qab = qb - qa
 
     # subdived circular integral into sections of
@@ -613,7 +718,7 @@ def mt_rad(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb,
             return complex_quad_2d(generatorFunc, qa, qb)
 
 
-def n_rad(float k, np.ndarray p, np.ndarray vecp, np.ndarray qa, np.ndarray qb, bool p_on_element):
+def n_rad(k, p, vecp, qa, qb, p_on_element):
     qab = qb - qa
     vec_q = normal_2d(qa, qb)
 

--- a/setup.py
+++ b/setup.py
@@ -13,6 +13,10 @@ pyntops = Extension("iops_pyx",
                     sources=["iops_pyx/helmholtz_integrals.pyx"],
                     include_dirs=[numpy.get_include()])
 
+#scintops = Extension("iops_sci",
+#                    sources=["iops_sci/helmholtz_integrals.pyx"],
+#                    include_dirs=[numpy.get_include()])
+
 aprops = Extension("aprops",
                     sources=["aprops/acoustic_properties.pyx"],
                     include_dirs=[numpy.get_include()])

--- a/tests/test_intops.py
+++ b/tests/test_intops.py
@@ -4,6 +4,7 @@ from scipy.special import hankel1
 
 import iops_pyx
 import iops_cpp
+import iops_sci
 
 
 class TestComplexQuadGenerator(unittest.TestCase):
@@ -85,6 +86,8 @@ class TestComputeL_2D(unittest.TestCase):
         zP = iops_pyx.l_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.l_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.l_2d(k, p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_L_02(self):
         k = 10.0
@@ -95,6 +98,8 @@ class TestComputeL_2D(unittest.TestCase):
         zP = iops_pyx.l_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.l_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.l_2d(k, p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_L_03(self):
         k = 0.0
@@ -105,6 +110,8 @@ class TestComputeL_2D(unittest.TestCase):
         zP = iops_pyx.l_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.l_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.l_2d(k, p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_L_04(self):
         k = 10.0
@@ -115,6 +122,8 @@ class TestComputeL_2D(unittest.TestCase):
         zP = iops_pyx.l_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.l_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.l_2d(k, p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
 
 class TestComputeM_2D(unittest.TestCase):
@@ -127,6 +136,13 @@ class TestComputeM_2D(unittest.TestCase):
         zP = iops_pyx.m_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.m_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.m_2d(k, p, a, b, pOnElement)
+        # Todo: Currently produces zP == -zS. Need to determine,
+        # if the sci implementation or the old python implementation
+        # is right. In terms of code the sci implementation is
+        # a more straight forward translation of the formulae in
+        # the thesis.
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_M_02(self):
         k = 10.0
@@ -137,6 +153,8 @@ class TestComputeM_2D(unittest.TestCase):
         zP = iops_pyx.m_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.m_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.m_2d(k, p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_M_03(self):
         k = 0.0
@@ -147,6 +165,10 @@ class TestComputeM_2D(unittest.TestCase):
         zP = iops_pyx.m_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.m_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.m_2d(k, p, a, b, pOnElement)
+        # The following agree (despite same implementation)
+        # because expected result is 0.
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_M_04(self):
         k = 10.0
@@ -157,6 +179,10 @@ class TestComputeM_2D(unittest.TestCase):
         zP = iops_pyx.m_2d(k, p, a, b, pOnElement)
         zC = iops_cpp.m_2d(k, p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.m_2d(k, p, a, b, pOnElement)
+        # The following agree (despite same implementation)
+        # because expected result is 0.
+        self.assertAlmostEqual(zP, zS)
 
 
 class TestComputeMt_2D(unittest.TestCase):
@@ -170,6 +196,8 @@ class TestComputeMt_2D(unittest.TestCase):
         zP = iops_pyx.mt_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.mt_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.mt_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_Mt_02(self):
         k = 10.0
@@ -181,28 +209,34 @@ class TestComputeMt_2D(unittest.TestCase):
         zP = iops_pyx.mt_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.mt_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.mt_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_Mt_03(self):
         k = 0.0
         p = np.array([0.0, 0.05], dtype=np.float32)
-        normal_p = np.array([-np.sqrt(0.5), -np.sqrt(0.5)], dtype=np.float32)
+        normal_p = np.array([-1, 0], dtype=np.float32)
         a = np.array([0.0, 0.00], dtype=np.float32)
         b = np.array([0.0, 0.10], dtype=np.float32)
         pOnElement = True
         zP = iops_pyx.mt_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.mt_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.mt_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS, 5)
 
     def test_compute_Mt_04(self):
         k = 10.0
         p = np.array([0.0, 0.05], dtype=np.float32)
-        normal_p = np.array([-np.sqrt(0.5), -np.sqrt(0.5)], dtype=np.float32)
+        normal_p = np.array([-1, 0], dtype=np.float32)
         a = np.array([0.0, 0.00], dtype=np.float32)
         b = np.array([0.0, 0.10], dtype=np.float32)
         pOnElement = True
         zP = iops_pyx.mt_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.mt_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.mt_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS, 5)
 
 
 class TestComputeN_2D(unittest.TestCase):
@@ -216,6 +250,8 @@ class TestComputeN_2D(unittest.TestCase):
         zP = iops_pyx.n_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.n_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.n_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_N_02(self):
         k = 10.0
@@ -227,28 +263,34 @@ class TestComputeN_2D(unittest.TestCase):
         zP = iops_pyx.n_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.n_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC, 6)
+        zS = iops_sci.n_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_N_03(self):
         k = 0.0
         p = np.array([0.0, 0.05], dtype=np.float32)
-        normal_p = np.array([-np.sqrt(0.5), -np.sqrt(0.5)], dtype=np.float32)
+        normal_p = np.array([-1, 0], dtype=np.float32)
         a = np.array([0.0, 0.00], dtype=np.float32)
         b = np.array([0.0, 0.10], dtype=np.float32)
         pOnElement = True
         zP = iops_pyx.n_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.n_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC)
+        zS = iops_sci.n_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS)
 
     def test_compute_N_04(self):
         k = 10.0
         p = np.array([0.0, 0.05], dtype=np.float32)
-        normal_p = np.array([-np.sqrt(0.5), -np.sqrt(0.5)], dtype=np.float32)
+        normal_p = np.array([-1, 0], dtype=np.float32)
         a = np.array([0.0, 0.00], dtype=np.float32)
         b = np.array([0.0, 0.10], dtype=np.float32)
         pOnElement = True
         zP = iops_pyx.n_2d(k, p, normal_p, a, b, pOnElement)
         zC = iops_cpp.n_2d(k, p, normal_p, a, b, pOnElement)
         self.assertAlmostEqual(zP, zC, 3)
+        zS = iops_sci.n_2d(k, p, normal_p, a, b, pOnElement)
+        self.assertAlmostEqual(zP, zS, 6)
 
 
 # -----------------------------------------------------------------------------


### PR DESCRIPTION
Adding yet another implementation of the helmholtz integral operators. 

These are using scikit integrators and aim to implement the formulae for Stephen's
paper as "verbatim" as possible. Only the singular and hypersingular integral
operators are implemented on simpliefied formulae that are not in the monograph.