### PR TITLE
Split up the cpp helmholtz functions into specialized versions for k=…

### DIFF
--- a/iops_cpp/helmholtz_integrals.pyx
+++ b/iops_cpp/helmholtz_integrals.pyx
@@ -16,7 +16,42 @@ cpdef l_2d(float k, float[:] p, float[:] qa, float[:] qb, bool p_on_element):
     cdef Float2 *cp = <Float2*>&p[0]
     cdef Float2 *a = <Float2*>&qa[0]
     cdef Float2 *b = <Float2*>&qb[0]
-    ComputeL_2D(k, cp[0], a[0], b[0], p_on_element, &result)
+    L_2D(k, cp, a, b, p_on_element, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef l_2d_on_k0(float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    L_2D_ON_K0(a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef l_2d_on(float k, float[:] p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    L_2D_ON(k, cp, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef l_2d_off_k0(float[:] p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    L_2D_OFF_K0(cp, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef l_2d_off(float k, float[:] p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    L_2D_OFF(k, cp, a, b, &result)
     return np.complex64(result.re + result.im * 1j)
 
 
@@ -25,7 +60,25 @@ cpdef m_2d(float k, float[:] p, float[:] qa, float[:] qb, bool p_on_element):
     cdef Float2 *cp = <Float2*>&p[0]
     cdef Float2 *a = <Float2*>&qa[0]
     cdef Float2 *b = <Float2*>&qb[0]
-    ComputeM_2D(k, cp[0], a[0], b[0], p_on_element, &result)
+    M_2D(k, cp, a, b, p_on_element, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef m_2d_off_k0(float[:] p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    M_2D_OFF_K0(cp, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef m_2d_off(float k, float[:] p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    M_2D_OFF(k, cp, a, b, &result)
     return np.complex64(result.re + result.im * 1j)
 
 
@@ -35,7 +88,27 @@ cpdef mt_2d(float k, float[:] p, float[:] normal_p, float[:] qa, float[:] qb, bo
     cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
     cdef Float2 *a = <Float2*>&qa[0]
     cdef Float2 *b = <Float2*>&qb[0]
-    ComputeMt_2D(k, cp[0], c_normal_p[0], a[0], b[0], p_on_element, &result)
+    MT_2D(k, cp, c_normal_p, a, b, p_on_element, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef mt_2d_off_k0(float[:] p, float[:] normal_p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    MT_2D_OFF_K0(cp, c_normal_p, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef mt_2d_off(float k, float[:] p, float[:] normal_p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    MT_2D_OFF(k, cp, c_normal_p, a, b, &result)
     return np.complex64(result.re + result.im * 1j)
 
 
@@ -45,8 +118,47 @@ cpdef n_2d(float k, float[:] p, float[:] normal_p, float[:] qa, float[:] qb, boo
     cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
     cdef Float2 *a = <Float2*>&qa[0]
     cdef Float2 *b = <Float2*>&qb[0]
-    ComputeN_2D(k, cp[0], c_normal_p[0], a[0], b[0], p_on_element, &result)
+    N_2D(k, cp, c_normal_p, a, b, p_on_element, &result)
     return np.complex64(result.re + result.im * 1j)
+
+
+cpdef n_2d_on_k0(float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    N_2D_ON_K0(a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef n_2d_on(float k, float[:] p, float[:] normal_p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    N_2D_ON(k, cp, c_normal_p, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef n_2d_off_k0(float[:] p, float[:] normal_p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    N_2D_OFF_K0(cp, c_normal_p, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
+
+cpdef n_2d_off(float k, float[:] p, float[:] normal_p, float[:] qa, float[:] qb):
+    cdef Complex result
+    cdef Float2 *cp = <Float2*>&p[0]
+    cdef Float2 *c_normal_p = <Float2*>&normal_p[0]
+    cdef Float2 *a = <Float2*>&qa[0]
+    cdef Float2 *b = <Float2*>&qb[0]
+    N_2D_OFF(k, cp, c_normal_p, a, b, &result)
+    return np.complex64(result.re + result.im * 1j)
+
 
 # -----------------------------------------------------------------------------
 # 3D

--- a/iops_cpp/iops_cpp.h
+++ b/iops_cpp/iops_cpp.h
@@ -153,7 +153,7 @@ typedef struct {
  *   start - 2-dimensional start point of the line-segment being integrated along.
  *   end   - 2-dimensional end point of the line-segment being integrated along.
  */
-std::complex<float> complexQuad2D(std::complex<float> (*integrand)(Float2, void*), void * state, IntRule1D intRule, Float2 start, Float2 end);
+std::complex<float> complexQuad2D(std::complex<float> (*integrand)(const Float2*, void*), void * state, IntRule1D intRule, const Float2 *start, const Float2 *end);
 
 /* An array containing the abscissa values of the default 1-dimensional integration rule. */
 extern float aX_1D[];
@@ -228,12 +228,29 @@ void semiCircleIntegralRule(int nSections, IntRule1D intRule, IntRule2D * pSemiC
 std::complex<float> complexLineIntegral(std::complex<float> (*integrand)(Float2, void*), void * state, IntRule2D intRule);
 
 
-void Hankel1(int order, float x, Complex * pz);
+void Hankel1(int order, float x, Complex* pz);
 
-void ComputeL_2D(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);
-void ComputeM_2D(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);
-void ComputeMt_2D(float k, Float2 p, Float2 normal_p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);
-void ComputeN_2D(float k, Float2 p, Float2 normal_p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);
+void L_2D(float k, const Float2* pp, const Float2* pa, const Float2* pb, bool pOnElement, Complex* pResult);
+void L_2D_ON_K0(const Float2* pa, const Float2* pb, Complex* pResult);
+void L_2D_ON(float k, const Float2* pp, const Float2* pa, const Float2* pb, Complex* pResult);
+void L_2D_OFF_K0(const Float2* pp, const Float2* pa, const Float2* pb, Complex* pResult);
+void L_2D_OFF(float k, const Float2* pp, const Float2* pa, const Float2* pb, Complex* pResult);
+
+void M_2D(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, bool pOnElement, Complex * pResult);
+void M_2D_ON_K0(const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult);
+void M_2D_ON(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult);
+void M_2D_OFF_K0(const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult);
+void M_2D_OFF(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult);
+
+void MT_2D(float k, const Float2 *pp, const Float2 *p_normal_p, const Float2 *pa, const Float2 *pb, bool pOnElement, Complex * pResult);
+void MT_2D_OFF_K0(const Float2 *pp, const Float2 *p_normal_p, const Float2 *pa, const Float2 *pb, Complex * pResult);
+void MT_2D_OFF(float k, const Float2 *pp, const Float2 *p_normal_p, const Float2 *pa, const Float2 *pb, Complex * pResult);
+
+void N_2D(float k, const Float2* pp, const Float2* p_normal_p, const Float2* pa, const Float2* pb, bool pOnElement, Complex* pResult);
+void N_2D_ON_K0(const Float2* pa, const Float2* pb, Complex* pResult);
+void N_2D_ON(float k, const Float2* pp, const Float2* p_normal_p, const Float2* pa, const Float2* pb, Complex* pResult);
+void N_2D_OFF_K0(const Float2* pp, const Float2* p_normal_p, const Float2* pa, const Float2* pb, Complex* pResult);
+void N_2D_OFF(float k, const Float2* pp, const Float2* p_normal_p, const Float2* pa, const Float2* pb, Complex* pResult);
 
 void ComputeL_RAD(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);
 void ComputeM_RAD(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult);

--- a/iops_cpp/iops_cpp.pxd
+++ b/iops_cpp/iops_cpp.pxd
@@ -41,10 +41,27 @@ cdef extern from "iops_cpp.h":
 
     void Hankel1(int order, float x, Complex * pz)
 
-    void ComputeL_2D(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)
-    void ComputeM_2D(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)
-    void ComputeMt_2D(float k, Float2 p, Float2 normal_p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)
-    void ComputeN_2D(float k, Float2 p, Float2 normal_p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)
+    void L_2D_ON_K0(const Float2 *pa, const Float2 *pb, Complex * pResult)
+    void L_2D_ON(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult)
+    void L_2D_OFF_K0(const Float2 *pp, const Float2 *pa, const Float2 *pb, Complex * pResult)
+    void L_2D_OFF(float k, const Float2* pp, const Float2* pa, const Float2* pb, Complex* pResult)
+    void L_2D(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, bool pOnElement, Complex * pResult)
+
+    void M_2D_OFF_K0(const Float2* pp, const Float2* pa, const Float2* pb, Complex * pResult)
+    void M_2D_OFF(float k, const Float2* pp, const Float2* pa, const Float2* pb, Complex * pResult)
+    void M_2D(float k, const Float2 *pp, const Float2 *pa, const Float2 *pb, bool pOnElement, Complex * pResult)
+
+    void MT_2D_OFF_K0(const Float2* p, const Float2* normal_p, const Float2* a, const Float2* b, Complex * pResult)
+    void MT_2D_OFF(float k, const Float2* p, const Float2* normal_p, const Float2* a, const Float2* b, Complex * pResult)
+    void MT_2D(float k, const Float2 *pp, const Float2 *p_normal_p, const Float2 *pa, const Float2 *pb, bool pOnElement,
+               Complex * pResult)
+
+    void N_2D_ON_K0(const Float2* a, const Float2* b, Complex* pResult)
+    void N_2D_ON(float k, const Float2* p, const Float2* normal_p, const Float2* a, const Float2* b, Complex * pResult)
+    void N_2D_OFF_K0(const Float2* p, const Float2* normal_p, const Float2* a, const Float2* b, Complex * pResult)
+    void N_2D_OFF(float k, const Float2* p, const Float2* normal_p, const Float2* a, const Float2* b, Complex * pResult)
+    void N_2D(float k, const Float2* pp, const Float2* p_normal_p, const Float2* pa, const Float2* pb, bool pOnElement,
+              Complex * pResult)
 
     void ComputeL_RAD(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)
     void ComputeM_RAD(float k, Float2 p, Float2 a, Float2 b, bool pOnElement, Complex * pResult)

--- a/iops_sci/iops_sci.py
+++ b/iops_sci/iops_sci.py
@@ -150,20 +150,6 @@ def l_2d(k, p, a, b, p_on_element):
             return l_2d_off(k, p, a, b)
 
 
-def int_m_2d(t, k, p, a, b):
-    q = lerp(t, a, b)
-    r = p - q
-    R = norm(r)
-    n_r = r / R
-    n_q = normal_2d(a, b)
-    return dgreen_dr_2d(k, R) * (-np.dot(n_r, n_q))
-
-
-def m_2d_off_k0(p, a, b):
-    l = norm(a - b)
-    return fixed_quad_complex(lambda t: int0_m_2d(t, p, a, b), 0, 1) * l
-
-
 def int0_m_2d(t, p, a, b):
     q = lerp(t, a, b)
     r = p - q
@@ -173,6 +159,20 @@ def int0_m_2d(t, p, a, b):
     return dgreen0_dr_2d(R) * (-np.dot(n_r, n_q))
 
 
+def m_2d_off_k0(p, a, b):
+    l = norm(a - b)
+    return fixed_quad_complex(lambda t: int0_m_2d(t, p, a, b), 0, 1) * l
+
+
+def int_m_2d(t, k, p, a, b):
+    q = lerp(t, a, b)
+    r = p - q
+    R = norm(r)
+    n_r = r / R
+    n_q = normal_2d(a, b)
+    return dgreen_dr_2d(k, R) * (-np.dot(n_r, n_q))
+
+
 def m_2d_off(k, p, a, b):
     l = norm(a - b)
     return fixed_quad_complex(lambda t: int_m_2d(t, k, p, a, b), 0, 1) * l
@@ -180,12 +180,8 @@ def m_2d_off(k, p, a, b):
 
 def m_2d(k, p, a, b, p_on_element):
     if p_on_element:
-        if k == 0.0:
-            # optimization because dot(n_r, n_q) == 0
-            return 0 + 0j
-        else:
-            # optimization because dot(n_r, n_q) == 0
-            return 0 + 0j
+        # optimization because dot(n_r, n_q) == 0
+        return 0 + 0j
     else:
         if k == 0.0:
             return m_2d_off_k0(p, a, b)

--- a/tests/perf_test.py
+++ b/tests/perf_test.py
@@ -22,48 +22,76 @@ class PerfExperiment2D(object):
         self.table_m = []
         self.table_mt = []
         self.table_n = []
+        self.specialized_modules = ["iops_sci", "iops_cpp"]
 
     def l_experiments(self, module):
         row = [module.__name__]
-        if module.__name__ == "iops_sci":
+        if module.__name__ in self.specialized_modules:
             row.append(timeit.timeit(lambda: module.l_2d_off_k0(self.p_off, self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d_off(16.0, self.p_off, self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d_on_k0(self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d_on(16.0, self.p_on, self.a, self.b), number=1000))
         else:
             row.append(timeit.timeit(lambda: module.l_2d(0.0, self.p_off, self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.l_2d(16.0, self.p_off, self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.l_2d(0.0, self.p_on, self.a, self.b, True), number=1000))
-        row.append(timeit.timeit(lambda: module.l_2d(16.0, self.p_on, self.a, self.b, True), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d(16.0, self.p_off, self.a, self.b, False), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d(0.0, self.p_on, self.a, self.b, True), number=1000))
+            row.append(timeit.timeit(lambda: module.l_2d(16.0, self.p_on, self.a, self.b, True), number=1000))
         self.table_l.append(row)
 
     def m_experiments(self, module):
         row = [module.__name__]
-        row.append(timeit.timeit(lambda: module.m_2d(0.0, self.p_off, self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.m_2d(16.0, self.p_off, self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.m_2d(0.0, self.p_on, self.a, self.b, True), number=1000))
-        row.append(timeit.timeit(lambda: module.m_2d(16.0, self.p_on, self.a, self.b, True), number=1000))
+        if module.__name__ in self.specialized_modules:
+            row.append(timeit.timeit(lambda: module.m_2d_off_k0(self.p_off, self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.m_2d_off(16.0, self.p_off, self.a, self.b), number=1000))
+            row.append("n/a")
+            row.append("n/a")
+        else:
+            row.append(timeit.timeit(lambda: module.m_2d(0.0, self.p_off, self.a, self.b, False), number=1000))
+            row.append(timeit.timeit(lambda: module.m_2d(16.0, self.p_off, self.a, self.b, False), number=1000))
+            row.append(timeit.timeit(lambda: module.m_2d(0.0, self.p_on, self.a, self.b, True), number=1000))
+            row.append(timeit.timeit(lambda: module.m_2d(16.0, self.p_on, self.a, self.b, True), number=1000))
         self.table_m.append(row)
 
     def mt_experiments(self, module):
         row = [module.__name__]
-        row.append(timeit.timeit(lambda: module.mt_2d(0.0, self.p_off, self.n_p_off,
-                                                                  self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.mt_2d(16.0, self.p_off, self.n_p_off,
-                                                                  self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.mt_2d(0.0, self.p_on, self.n_p_on,
-                                                                  self.a, self.b, True), number=1000))
-        row.append(timeit.timeit(lambda: module.mt_2d(16.0, self.p_on, self.n_p_on,
-                                                                  self.a, self.b, True), number=1000))
+        if module.__name__ in self.specialized_modules:
+            row.append(timeit.timeit(lambda: module.mt_2d_off_k0(self.p_off, self.n_p_off, self.a, self.b),
+                                     number=1000))
+            row.append(timeit.timeit(lambda: module.mt_2d_off(16.0, self.p_off, self.n_p_off, self.a, self.b),
+                                     number=1000))
+            row.append("n/a")
+            row.append("n/a")
+        else:
+            row.append(
+                timeit.timeit(lambda: module.mt_2d(0.0, self.p_off, self.n_p_off, self.a, self.b, False),
+                              number=1000))
+            row.append(timeit.timeit(lambda: module.mt_2d(16.0, self.p_off, self.n_p_off, self.a, self.b, False),
+                                     number=1000))
+            row.append(timeit.timeit(lambda: module.mt_2d(0.0, self.p_on, self.n_p_on, self.a, self.b, True),
+                                     number=1000))
+            row.append(timeit.timeit(lambda: module.mt_2d(16.0, self.p_on, self.n_p_on, self.a, self.b, True),
+                                     number=1000))
         self.table_mt.append(row)
 
     def n_experiments(self, module):
         row = [module.__name__]
-        row.append(timeit.timeit(lambda: module.n_2d(0.0, self.p_off, self.n_p_off,
-                                                                self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.n_2d(16.0, self.p_off, self.n_p_off,
-                                                                self.a, self.b, False), number=1000))
-        row.append(timeit.timeit(lambda: module.n_2d(0.0, self.p_on, self.n_p_on,
-                                                                self.a, self.b, True), number=1000))
-        row.append(timeit.timeit(lambda: module.n_2d(16.0, self.p_on, self.n_p_on,
-                                                                self.a, self.b, True), number=1000))
+        if module.__name__ in self.specialized_modules:
+            row.append(timeit.timeit(lambda: module.n_2d_off_k0(self.p_off, self.n_p_off,
+            self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d_off(16.0, self.p_off, self.n_p_off,
+            self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d_on_k0(self.a, self.b), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d_on(16.0, self.p_on, self.n_p_on,
+            self.a, self.b), number=1000))
+        else:
+            row.append(timeit.timeit(lambda: module.n_2d(0.0, self.p_off, self.n_p_off,
+            self.a, self.b, False), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d(16.0, self.p_off, self.n_p_off,
+            self.a, self.b, False), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d(0.0, self.p_on, self.n_p_on,
+            self.a, self.b, True), number=1000))
+            row.append(timeit.timeit(lambda: module.n_2d(16.0, self.p_on, self.n_p_on,
+            self.a, self.b, True), number=1000))
         self.table_n.append(row)
 
     def run(self):

--- a/tests/test_intops.py
+++ b/tests/test_intops.py
@@ -99,7 +99,11 @@ class TestComputeL_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.l_2d(k, self.p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.l_2d_off_k0(self.p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.l_2d(k, self.p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.l_2d_off_k0(self.p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_L_02(self):
@@ -110,7 +114,11 @@ class TestComputeL_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.l_2d(k, self.p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.l_2d_off(k, self.p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.l_2d(k, self.p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.l_2d_off(k, self.p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_L_03(self):
@@ -121,7 +129,11 @@ class TestComputeL_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.l_2d(k, self.p_on, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.l_2d_on_k0(self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.l_2d(k, self.p_on, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.l_2d_on_k0(self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_L_04(self):
@@ -132,7 +144,11 @@ class TestComputeL_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.l_2d(k, self.p_on, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.l_2d_on(k, self.p_on, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.l_2d(k, self.p_on, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld, 6)
+        sci = iops_sci.l_2d_on(k, self.p_on, self.a, self.b)
         self.assertAlmostEqual(sci, gld, 6)
 
 
@@ -145,7 +161,11 @@ class TestComputeM_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.m_2d(k, self.p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.m_2d_off_k0(self.p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.m_2d(k, self.p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.m_2d_off_k0(self.p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_M_02(self):
@@ -157,6 +177,10 @@ class TestComputeM_2D(Test2D):
         cpp = iops_cpp.m_2d(k, self.p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld, 6)
         sci = iops_sci.m_2d(k, self.p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(cpp, gld, 6)
+        sci = iops_sci.m_2d_off(k, self.p_off, self.a, self.b)
+        self.assertAlmostEqual(sci, gld, 6)
+        sci = iops_sci.m_2d_off(k, self.p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld, 6)
 
 
@@ -193,7 +217,11 @@ class TestComputeMt_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.mt_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.mt_2d_off_k0(self.p_off, self.n_p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.mt_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.mt_2d_off_k0(self.p_off, self.n_p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_Mt_02(self):
@@ -204,7 +232,11 @@ class TestComputeMt_2D(Test2D):
         self.assertAlmostEqual(pyx, gld, 6)
         cpp = iops_cpp.mt_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld, 6)
+        cpp = iops_cpp.mt_2d_off(k, self.p_off, self.n_p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld, 6)
         sci = iops_sci.mt_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld, 6)
+        sci = iops_sci.mt_2d_off(k, self.p_off, self.n_p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld, 6)
 
     def test_compute_Mt_03(self):
@@ -239,7 +271,11 @@ class TestComputeN_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.n_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
+        cpp = iops_cpp.n_2d_off_k0(self.p_off, self.n_p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
         sci = iops_sci.n_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.n_2d_off_k0(self.p_off, self.n_p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_N_02(self):
@@ -250,7 +286,11 @@ class TestComputeN_2D(Test2D):
         self.assertAlmostEqual(pyx, gld, 5)
         cpp = iops_cpp.n_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld, 5)
+        cpp = iops_cpp.n_2d_off(k, self.p_off, self.n_p_off, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld, 5)
         sci = iops_sci.n_2d(k, self.p_off, self.n_p_off, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld, 5)
+        sci = iops_sci.n_2d_off(k, self.p_off, self.n_p_off, self.a, self.b)
         self.assertAlmostEqual(sci, gld, 5)
 
     def test_compute_N_03(self):
@@ -261,7 +301,11 @@ class TestComputeN_2D(Test2D):
         self.assertAlmostEqual(pyx, gld)
         cpp = iops_cpp.n_2d(k, self.p_on, self.n_p_on, self.a, self.b, p_on_element)
         self.assertAlmostEqual(cpp, gld)
-        sci = iops_sci.n_2d(k, self.p_on, self.n_p_off, self.a, self.b, p_on_element)
+        cpp = iops_cpp.n_2d_on_k0(self.a, self.b)
+        self.assertAlmostEqual(cpp, gld)
+        sci = iops_sci.n_2d(k, self.p_on, self.n_p_on, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld)
+        sci = iops_sci.n_2d_on_k0(self.a, self.b)
         self.assertAlmostEqual(sci, gld)
 
     def test_compute_N_04(self):
@@ -271,8 +315,12 @@ class TestComputeN_2D(Test2D):
         pyx = iops_pyx.n_2d(k, self.p_on, self.n_p_on, self.a, self.b, p_on_element)
         self.assertAlmostEqual(pyx, gld, 4)
         cpp = iops_cpp.n_2d(k, self.p_on, self.n_p_on, self.a, self.b, p_on_element)
-        self.assertAlmostEqual(cpp, gld, 5)
+        self.assertAlmostEqual(cpp, gld, 4)
+        cpp = iops_cpp.n_2d_on(k, self.p_on, self.n_p_on, self.a, self.b)
+        self.assertAlmostEqual(cpp, gld, 4)
         sci = iops_sci.n_2d(k, self.p_on, self.n_p_on, self.a, self.b, p_on_element)
+        self.assertAlmostEqual(sci, gld, 4)
+        sci = iops_sci.n_2d_on(k, self.p_on, self.n_p_on, self.a, self.b)
         self.assertAlmostEqual(sci, gld, 4)
 
 


### PR DESCRIPTION
…=0, p on element and off. There is now API parity between the iops_sci and iops_cpp integral operators. All tests extended to test those new methods.